### PR TITLE
Adapt interface to CARDsflow

### DIFF
--- a/gelataio_boy_control/CMakeLists.txt
+++ b/gelataio_boy_control/CMakeLists.txt
@@ -146,6 +146,8 @@ include_directories(
 ## The recommended prefix ensures that target names across packages don't collide
 add_executable(scooping_planning src/main.cpp src/scooping.cpp src/scooping_ros.cpp)
 
+add_executable(sim_joint_state_converter src/sim_joint_state_converter.cpp)
+
 ## Rename C++ executable without prefix
 ## The above recommended prefix causes long target names, the following renames the
 ## target back to the shorter version for ease of user use
@@ -164,6 +166,9 @@ target_link_libraries(scooping_planning
 target_link_libraries(${PROJECT_NAME}
    ${catkin_LIBRARIES}
  )
+
+target_link_libraries(sim_joint_state_converter
+        ${catkin_LIBRARIES})
 #############
 ## Install ##
 #############

--- a/gelataio_boy_control/include/gelataio_boy_control/plan_executor.h
+++ b/gelataio_boy_control/include/gelataio_boy_control/plan_executor.h
@@ -13,12 +13,11 @@ public:
 
 class CardsflowPlanExecutor : public plan_executor {
 public:
-    explicit CardsflowPlanExecutor(std::string group_name, ros::NodeHandle *nh);
+    explicit CardsflowPlanExecutor(ros::NodeHandle *nh);
 
     virtual bool executePlan(moveit::planning_interface::MoveGroupInterface::Plan &plan) override;
 
 private:
-    std::string group_name;
     ros::Publisher joint_target_pub;
 };
 

--- a/gelataio_boy_control/include/gelataio_boy_control/plan_executor.h
+++ b/gelataio_boy_control/include/gelataio_boy_control/plan_executor.h
@@ -19,7 +19,7 @@ public:
 
 private:
     std::string group_name;
-    std::map<std::string, ros::Publisher> publishers;
+    ros::Publisher joint_target_pub;
 };
 
 #endif //SRC_PLAN_EXECUTOR_H

--- a/gelataio_boy_control/include/gelataio_boy_control/scooping.h
+++ b/gelataio_boy_control/include/gelataio_boy_control/scooping.h
@@ -40,7 +40,7 @@ private:
     HandController right_arm, left_arm;
     ros::NodeHandle *node_handle;
 
-    CardsflowPlanExecutor *right_cardsflow, *left_cardsflow;
+    CardsflowPlanExecutor *cardsflow;
 
     HandController* active_arm;
 

--- a/gelataio_boy_control/launch/sim_joint_state_converter.launch
+++ b/gelataio_boy_control/launch/sim_joint_state_converter.launch
@@ -1,0 +1,6 @@
+<launch>
+
+  <node name="sim_joint_state_converter" pkg="gelataio_boy_control" type="sim_joint_state_converter" respawn="false" output="screen">
+  </node>
+
+</launch>

--- a/gelataio_boy_control/scripts/set_icecream_pos.sh
+++ b/gelataio_boy_control/scripts/set_icecream_pos.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+rostopic pub /joint_targets sensor_msgs/JointState "{name: [ice_left_linear, ice_right_linear], position:[0.25, 0.25], velocity:[0.0, 0.0]}"

--- a/gelataio_boy_control/scripts/start_kindyn.sh
+++ b/gelataio_boy_control/scripts/start_kindyn.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-roslaunch kindyn robot.launch robot_name:=roboy_icecream start_controllers:='shoulder_left_axis0 shoulder_left_axis1 shoulder_left_axis2 elbow_left wrist_left shoulder_right_axis0 shoulder_right_axis1 shoulder_right_axis2 elbow_right wrist_right' 

--- a/gelataio_boy_control/scripts/start_sim_kindyn.sh
+++ b/gelataio_boy_control/scripts/start_sim_kindyn.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+roslaunch kindyn robot.launch robot_name:=roboy_icecream urdf_file_name:=cardsflow.urdf simulated:=true

--- a/gelataio_boy_control/src/hand_controller.cpp
+++ b/gelataio_boy_control/src/hand_controller.cpp
@@ -2,9 +2,10 @@
 
 using namespace std;
 
-HandController::HandController(const std::string &group_name, int planning_attempts) : m_plan_executor_ptr(nullptr),
-                                                                                       status(HandController::Status::IDLE),
-                                                                                       planning_time(10.0) {
+HandController::HandController(const std::string &group_name, int planning_attempts)
+        : m_plan_executor_ptr(nullptr),
+          status(HandController::Status::IDLE),
+          planning_time(10.0) {
     this->m_move_group_ptr = new moveit::planning_interface::MoveGroupInterface(group_name + "_arm");
     this->m_planning_attempts = planning_attempts;
 
@@ -18,7 +19,8 @@ HandController::PlanningResult HandController::plan(double tolerance) {
     this->m_move_group_ptr->setStartStateToCurrentState();
     this->m_move_group_ptr->setGoalTolerance(tolerance);
 
-    stringstream ss; ss << "Current joint state:" << endl;
+    stringstream ss;
+    ss << "Current joint state:" << endl;
     for (const auto &m : this->jointStatus()) {
         ss << "\t" << m.first << ":\t" << m.second << endl;
     }
@@ -47,11 +49,13 @@ bool HandController::planAndExecute() {
         ROS_INFO("Plan found.");
 
         this->status = Status::EXECUTING;
+        bool execution_success = true;
         if (this->m_plan_executor_ptr) {
-            this->m_plan_executor_ptr->executePlan(planning_result.plan);
-        }
-        bool execution_success = this->m_move_group_ptr->execute(planning_result.plan) ==
+            execution_success &= this->m_plan_executor_ptr->executePlan(planning_result.plan);
+        } else {
+            execution_success &= this->m_move_group_ptr->execute(planning_result.plan) ==
                                  moveit::planning_interface::MoveItErrorCode::SUCCESS;
+        }
         this->status = Status::IDLE;
         return execution_success;
     } else {
@@ -204,4 +208,5 @@ bool HandController::goHome() {
     this->m_move_group_ptr->setJointValueTarget(desiredState);
     return this->planAndExecute();
 }
+
 

--- a/gelataio_boy_control/src/plan_executor.cpp
+++ b/gelataio_boy_control/src/plan_executor.cpp
@@ -7,23 +7,7 @@
 #include <std_msgs/Float32.h>
 
 CardsflowPlanExecutor::CardsflowPlanExecutor(std::string group_name, ros::NodeHandle *nh) : group_name(group_name) {
-    std::string axis0_prefix, axis1_prefix, axis2_prefix, elbow_prefix;
-    axis0_prefix = "shoulder_" + group_name + "_axis0";
-    axis1_prefix = "shoulder_" + group_name + "_axis1";
-    axis2_prefix = "shoulder_" + group_name + "_axis2";
-    elbow_prefix = "elbow_" + group_name;
-    auto create_pub = [&](std::string prefix) {
-        return std::make_pair(prefix,
-                nh->advertise<std_msgs::Float32>("/" + prefix + "/" + prefix + "/target", 1));
-    };
-    publishers.insert(create_pub("shoulder_" + group_name + "_axis0"));
-    publishers.insert(create_pub("shoulder_" + group_name + "_axis1"));
-    publishers.insert(create_pub("shoulder_" + group_name + "_axis2"));
-    publishers.insert(create_pub("elbow_" + group_name));
-    publishers.insert(create_pub("wrist_" + group_name + "_axis0"));
-    publishers.insert(create_pub("wrist_" + group_name + "_axis1"));
-    publishers.insert(create_pub("wrist_" + group_name + "_axis2"));
-
+    joint_target_pub = nh->advertise<sensor_msgs::JointState>("/joint_targets", 1);
 }
 
 bool CardsflowPlanExecutor::executePlan(moveit::planning_interface::MoveGroupInterface::Plan &plan) {
@@ -31,19 +15,20 @@ bool CardsflowPlanExecutor::executePlan(moveit::planning_interface::MoveGroupInt
     ss << "Moving " << group_name << " arm using CARDSflow." << std::endl;
     ROS_INFO_STREAM(ss.str());
 
-    for (int t = 0; t<plan.trajectory_.joint_trajectory.points.size(); t++) {
-        if (t > 0) {
-            ros::Duration dt = plan.trajectory_.joint_trajectory.points[t].time_from_start
-                    - plan.trajectory_.joint_trajectory.points[t-1].time_from_start;
-            dt.sleep();
+    sensor_msgs::JointState targets;
+    targets.name = plan.trajectory_.joint_trajectory.joint_names;
 
-        }
-        for (int i = 0; i<plan.trajectory_.joint_trajectory.joint_names.size(); i++) {
-            std::string joint_name = plan.trajectory_.joint_trajectory.joint_names[i];
-            std_msgs::Float32 value;
-            value.data = plan.trajectory_.joint_trajectory.points[t].positions[i];
-            publishers.at(joint_name).publish(value); //TODO
-        }
+    ros::Duration lastTime(0);
+
+    for (const auto &state : plan.trajectory_.joint_trajectory.points) {
+        ros::Duration dt = state.time_from_start - lastTime;
+        dt.sleep();
+        lastTime = state.time_from_start;
+
+        targets.position = state.positions;
+        targets.velocity = state.velocities;
+        joint_target_pub.publish(targets);
     }
+
     return true;
 }

--- a/gelataio_boy_control/src/plan_executor.cpp
+++ b/gelataio_boy_control/src/plan_executor.cpp
@@ -6,14 +6,12 @@
 #include <gelataio_boy_control/plan_executor.h>
 #include <std_msgs/Float32.h>
 
-CardsflowPlanExecutor::CardsflowPlanExecutor(std::string group_name, ros::NodeHandle *nh) : group_name(group_name) {
+CardsflowPlanExecutor::CardsflowPlanExecutor(ros::NodeHandle *nh) {
     joint_target_pub = nh->advertise<sensor_msgs::JointState>("/joint_targets", 1);
 }
 
 bool CardsflowPlanExecutor::executePlan(moveit::planning_interface::MoveGroupInterface::Plan &plan) {
-    std::stringstream ss;
-    ss << "Moving " << group_name << " arm using CARDSflow." << std::endl;
-    ROS_INFO_STREAM(ss.str());
+    ROS_INFO("Moving robot using CARDSflow");
 
     sensor_msgs::JointState targets;
     targets.name = plan.trajectory_.joint_trajectory.joint_names;

--- a/gelataio_boy_control/src/scooping.cpp
+++ b/gelataio_boy_control/src/scooping.cpp
@@ -18,14 +18,13 @@ ScoopingMain::ScoopingMain(ros::NodeHandle *handle, bool simulation_only)
         right_hand = new DummyHand("right hand");
         right_arm.setHandInterface(right_hand);
     } else { // Execution on Hardware
-        left_cardsflow = new CardsflowPlanExecutor("left", handle);
+        cardsflow = new CardsflowPlanExecutor(handle);
         left_hand = new DummyHand("left hand");
-        left_arm.addPlanExecutor(left_cardsflow);
+        left_arm.addPlanExecutor(cardsflow);
         left_arm.setHandInterface(left_hand);
 
-        right_cardsflow = new CardsflowPlanExecutor("right", handle);
         right_hand = new DummyHand("right hand");
-        right_arm.addPlanExecutor(right_cardsflow);
+        right_arm.addPlanExecutor(cardsflow);
         right_arm.setHandInterface(right_hand);
     }
 
@@ -38,8 +37,7 @@ ScoopingMain::ScoopingMain(ros::NodeHandle *handle, bool simulation_only)
 
 ScoopingMain::~ScoopingMain() {
     this->status_watcher->join();
-    delete left_cardsflow;
-    delete right_cardsflow;
+    delete cardsflow;
     delete left_hand;
     delete right_hand;
 

--- a/gelataio_boy_control/src/scooping_ros.cpp
+++ b/gelataio_boy_control/src/scooping_ros.cpp
@@ -12,7 +12,7 @@ using namespace roboy_control_msgs;
 using namespace std;
 
 
-ScoopingROS::ScoopingROS(ros::NodeHandle *handle) : nh(handle), app(handle, true), busy(false), executor(nullptr) {
+ScoopingROS::ScoopingROS(ros::NodeHandle *handle) : nh(handle), app(handle, false), busy(false), executor(nullptr) {
 
 }
 

--- a/gelataio_boy_control/src/sim_joint_state_converter.cpp
+++ b/gelataio_boy_control/src/sim_joint_state_converter.cpp
@@ -10,7 +10,7 @@
 using namespace std;
 
 static ros::Publisher pub;
-const static vector<int> joint_ids = {7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
+const static vector<int> joint_ids = {0, 1, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
 static vector<string> joint_names;
 
 void jointStateCallback(const roboy_simulation_msgs::JointState &state) {
@@ -19,7 +19,6 @@ void jointStateCallback(const roboy_simulation_msgs::JointState &state) {
         s.name.push_back(joint_names[index]);
         s.position.push_back(state.q[index]);
         s.velocity.push_back(state.qd[index]);
-
     }
     pub.publish(s);
     ROS_INFO_THROTTLE(10.0, "I'm alive.");

--- a/gelataio_boy_control/src/sim_joint_state_converter.cpp
+++ b/gelataio_boy_control/src/sim_joint_state_converter.cpp
@@ -1,0 +1,49 @@
+//
+// Created by arne on 26.08.19.
+//
+
+#include <iostream>
+#include <ros/ros.h>
+#include <roboy_simulation_msgs/JointState.h>
+#include <sensor_msgs/JointState.h>
+
+using namespace std;
+
+static ros::Publisher pub;
+const static vector<int> joint_ids = {7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
+static vector<string> joint_names;
+
+void jointStateCallback(const roboy_simulation_msgs::JointState &state) {
+    sensor_msgs::JointState s;
+    for (const int index : joint_ids) {
+        s.name.push_back(joint_names[index]);
+        s.position.push_back(state.q[index]);
+        s.velocity.push_back(state.qd[index]);
+
+    }
+    pub.publish(s);
+    ROS_INFO_THROTTLE(10.0, "I'm alive.");
+}
+
+int main(int argc, char **argv) {
+
+    ros::init(argc, argv, "sim_joint_state_converter");
+    ros::NodeHandle nh;
+
+    if (ros::param::has("joint_names")) {
+        auto sub = nh.subscribe("/joint_state", 10, jointStateCallback);
+        pub = nh.advertise<sensor_msgs::JointState>("/joint_states", 10);
+        ROS_INFO("Converted started successfully.");
+
+        ros::param::get("joint_names", joint_names);
+        stringstream ss; ss << "Joint names are: [";
+        int i = 0;
+        for (const auto &s : joint_names) ss << "\t" << i++ << ": " << s << endl;
+        ROS_INFO_STREAM(ss.str());
+
+        ros::spin();
+    } else {
+        ROS_ERROR("No parameter joint_names.");
+        return -1;
+    }
+}


### PR DESCRIPTION
# What changed here:
- publish joint position to new topic /joint_targets (https://github.com/Roboy/gelataio-boy/issues/30)
- write a converter from /joint_state (CARDsflow) to /joint_states (MoveIT), which is required when we don't have external robot state running.

## Note 
In order to not completely spam you logs with errors and to make moveIT work, you need to pull:
- latest master on CARDsflow/kindyn
- hackthon branch on CARDsflow/robots